### PR TITLE
Extra assertions and warns

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,7 +193,7 @@
             warnings =
               # Prevent lockout from local or upstream token breakage
               lib.optional ((cfg.github.teams != [] && cfg.github.users == []) || (cfg.gitlab.groups != [] && cfg.gitlab.users == []))
-                "programs.auth-keys-hub recommends declaring at least 1 github or gitlab user when github teams or gitlab groups are used"
+              "programs.auth-keys-hub recommends declaring at least 1 github or gitlab user when github teams or gitlab groups are used"
               ++
               # Prevent lockout from other edge cases, ex: a) removal of auth-keys-hub module without setting up keys; b) bugs; c) tail events, etc
               lib.optional (


### PR DESCRIPTION
* Extra assertions to:
  * Prevent lockout from misconfigured gitlab groups
  * Prevent lockouts from not configuring any keys, ex: fail2ban breaking existing conns on a subsequent ssh attempt
 
* Extra warnings to:
  * Prevent lockout from local or upstream token breakage when teams or groups are in use
  * Prevent lockout from other edge cases