### PR TITLE
fix: installCheckPhase bash glob bug workaround

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,12 @@
               options = ["--release"];
             };
 
+            # Override default installCheckPhase to work around the bug fixed
+            # in this PR: https://github.com/NixOS/nixpkgs/pull/477878
+            installCheckPhase = ''
+              $out/bin/auth-keys-hub --version
+            '';
+
             meta.mainProgram = pname;
           };
         };


### PR DESCRIPTION
Override the default Crystal buildCrystalPackage installCheckPhase which fails with "unary operator expected" due to a bash glob pattern bug in nixpkgs. Use a simple --version check instead.

See https://github.com/NixOS/nixpkgs/pull/477878.